### PR TITLE
Fixes for test suite on ARM64

### DIFF
--- a/src/adiabatic_index.h
+++ b/src/adiabatic_index.h
@@ -117,8 +117,8 @@ __attribute__((always_inline, const)) INLINE static float pow_gamma(float x) {
   const float icbrt = icbrtf(x); /* x^(-1/3) */
   return icbrt * x * x;          /* x^(5/3) */
 #else
-  const float cbrt = cbrtf(x);                 /* x^(1/3) */
-  return cbrt * cbrt * x;                      /* x^(5/3) */
+  const float cbrt = cbrtf(x); /* x^(1/3) */
+  return cbrt * cbrt * x;      /* x^(5/3) */
 #endif  // WITH_ICBRTF
 
 #elif defined(HYDRO_GAMMA_7_5)
@@ -128,10 +128,10 @@ __attribute__((always_inline, const)) INLINE static float pow_gamma(float x) {
 #elif defined(HYDRO_GAMMA_4_3)
 
 #ifdef WITH_ICBRTF
-  const float icbrt = icbrtf(x);               /* x^(-1/3) */
-  return icbrt * icbrt * x * x;                /* x^(4/3) */
+  const float icbrt = icbrtf(x); /* x^(-1/3) */
+  return icbrt * icbrt * x * x;  /* x^(4/3) */
 #else
-  return cbrtf(x) * x;                   /* x^(4/3) */
+  return cbrtf(x) * x; /* x^(4/3) */
 #endif  // WITH_ICBRTF
 
 #elif defined(HYDRO_GAMMA_2_1)
@@ -161,8 +161,8 @@ __attribute__((always_inline, const)) INLINE static float pow_gamma_minus_one(
   const float icbrt = icbrtf(x); /* x^(-1/3) */
   return x * icbrt;              /* x^(2/3) */
 #else
-  const float cbrt = cbrtf(x);                 /* x^(1/3) */
-  return cbrt * cbrt;                          /* x^(2/3) */
+  const float cbrt = cbrtf(x); /* x^(1/3) */
+  return cbrt * cbrt;          /* x^(2/3) */
 #endif  // WITH_ICBRTF
 
 #elif defined(HYDRO_GAMMA_7_5)
@@ -172,10 +172,10 @@ __attribute__((always_inline, const)) INLINE static float pow_gamma_minus_one(
 #elif defined(HYDRO_GAMMA_4_3)
 
 #ifdef WITH_ICBRTF
-  const float icbrt = icbrtf(x);               /* x^(-1/3) */
-  return x * icbrt * icbrt;                    /* x^(1/3) */
+  const float icbrt = icbrtf(x); /* x^(-1/3) */
+  return x * icbrt * icbrt;      /* x^(1/3) */
 #else
-  return cbrtf(x);                       /* x^(1/3) */
+  return cbrtf(x); /* x^(1/3) */
 #endif  // WITH_ICBRTF
 
 #elif defined(HYDRO_GAMMA_2_1)
@@ -205,8 +205,8 @@ pow_minus_gamma_minus_one(float x) {
   const float icbrt = icbrtf(x); /* x^(-1/3) */
   return icbrt * icbrt;          /* x^(-2/3) */
 #else
-  const float cbrt_inv = 1.f / cbrtf(x);       /* x^(-1/3) */
-  return cbrt_inv * cbrt_inv;                  /* x^(-2/3) */
+  const float cbrt_inv = 1.f / cbrtf(x); /* x^(-1/3) */
+  return cbrt_inv * cbrt_inv;            /* x^(-2/3) */
 #endif  // WITH_ICBRTF
 
 #elif defined(HYDRO_GAMMA_7_5)
@@ -216,9 +216,9 @@ pow_minus_gamma_minus_one(float x) {
 #elif defined(HYDRO_GAMMA_4_3)
 
 #ifdef WITH_ICBRTF
-  return icbrtf(x);                            /* x^(-1/3) */
+  return icbrtf(x); /* x^(-1/3) */
 #else
-  return 1.f / cbrtf(x);                 /* x^(-1/3) */
+  return 1.f / cbrtf(x); /* x^(-1/3) */
 #endif  // WITH_ICBRTF
 
 #elif defined(HYDRO_GAMMA_2_1)
@@ -264,7 +264,7 @@ __attribute__((always_inline, const)) INLINE static float pow_minus_gamma(
 #elif defined(HYDRO_GAMMA_4_3)
 
 #ifdef WITH_ICBRTF
-  const float cbrt_inv = icbrtf(x);            /* x^(-1/3) */
+  const float cbrt_inv = icbrtf(x); /* x^(-1/3) */
 #else
   const float cbrt_inv = 1.f / cbrtf(x); /* x^(-1/3) */
 #endif  // WITH_ICBRTF

--- a/src/equation_of_state.c
+++ b/src/equation_of_state.c
@@ -39,6 +39,6 @@ struct eos_parameters eos = {.isothermal_internal_energy = -1.};
 struct eos_parameters eos;
 #endif
 
-#else  /* i.e. not __APPLE__ */
+#else /* i.e. not __APPLE__ */
 struct eos_parameters eos;
 #endif /* __APPLE__ */

--- a/src/kernel_hydro.h
+++ b/src/kernel_hydro.h
@@ -69,7 +69,7 @@ static const float kernel_coeffs[(kernel_degree + 1) * (kernel_ivals + 1)]
 /* Coefficients for the kernel. */
 #define kernel_name "Quartic spline (M5)"
 #define kernel_degree 4 /* Degree of the polynomial */
-#define kernel_ivals 5  /* Number of branches */
+#define kernel_ivals 5 /* Number of branches */
 #if defined(HYDRO_DIMENSION_3D)
 #define kernel_gamma ((float)(2.018932))
 #define kernel_constant ((float)(15625. * M_1_PI / 512.))
@@ -95,7 +95,7 @@ static const float kernel_coeffs[(kernel_degree + 1) * (kernel_ivals + 1)]
 /* Coefficients for the kernel. */
 #define kernel_name "Quintic spline (M6)"
 #define kernel_degree 5 /* Degree of the polynomial */
-#define kernel_ivals 3  /* Number of branches */
+#define kernel_ivals 3 /* Number of branches */
 #if defined(HYDRO_DIMENSION_3D)
 #define kernel_gamma ((float)(2.195775))
 #define kernel_constant ((float)(2187. * M_1_PI / 40.))
@@ -123,7 +123,7 @@ static const float kernel_coeffs[(kernel_degree + 1) * (kernel_ivals + 1)]
 /* Coefficients for the kernel. */
 #define kernel_name "Wendland C2"
 #define kernel_degree 5 /* Degree of the polynomial */
-#define kernel_ivals 1  /* Number of branches */
+#define kernel_ivals 1 /* Number of branches */
 #if defined(HYDRO_DIMENSION_1D)
 /* Wendland C* have different form in 1D than 2D/3D */
 #define kernel_gamma ((float)(1.620185))
@@ -151,7 +151,7 @@ static const float kernel_coeffs[(kernel_degree + 1) * (kernel_ivals + 1)]
 /* Coefficients for the kernel. */
 #define kernel_name "Wendland C4"
 #define kernel_degree 8 /* Degree of the polynomial */
-#define kernel_ivals 1  /* Number of branches */
+#define kernel_ivals 1 /* Number of branches */
 #if defined(HYDRO_DIMENSION_3D)
 #define kernel_gamma ((float)(2.207940))
 #define kernel_constant ((float)(495. * M_1_PI / 32.))
@@ -174,7 +174,7 @@ static const float kernel_coeffs[(kernel_degree + 1) * (kernel_ivals + 1)]
 /* Coefficients for the kernel. */
 #define kernel_name "Wendland C6"
 #define kernel_degree 11 /* Degree of the polynomial */
-#define kernel_ivals 1   /* Number of branches */
+#define kernel_ivals 1 /* Number of branches */
 #if defined(HYDRO_DIMENSION_3D)
 #define kernel_gamma ((float)(2.449490))
 #define kernel_constant ((float)(1365. * M_1_PI / 64.))

--- a/src/runner_doiact_functions_hydro.h
+++ b/src/runner_doiact_functions_hydro.h
@@ -883,9 +883,9 @@ void DOPAIR_SUBSET_BRANCH(struct runner *r, struct cell *restrict ci,
   /* Get the sorting index. */
   int sid = 0;
   for (int k = 0; k < 3; k++)
-    sid = 3 * sid + ((cj->loc[k] - ci->loc[k] + shift[k] < 0)
-                         ? 0
-                         : (cj->loc[k] - ci->loc[k] + shift[k] > 0) ? 2 : 1);
+    sid = 3 * sid + ((cj->loc[k] - ci->loc[k] + shift[k] < 0)   ? 0
+                     : (cj->loc[k] - ci->loc[k] + shift[k] > 0) ? 2
+                                                                : 1);
 
   /* Switch the cells around? */
   const int flipped = runner_flip[sid];

--- a/src/runner_doiact_functions_stars.h
+++ b/src/runner_doiact_functions_stars.h
@@ -992,9 +992,9 @@ void DOPAIR1_SUBSET_BRANCH_STARS(struct runner *r, struct cell *restrict ci,
   /* Get the sorting index. */
   int sid = 0;
   for (int k = 0; k < 3; k++)
-    sid = 3 * sid + ((cj->loc[k] - ci->loc[k] + shift[k] < 0)
-                         ? 0
-                         : (cj->loc[k] - ci->loc[k] + shift[k] > 0) ? 2 : 1);
+    sid = 3 * sid + ((cj->loc[k] - ci->loc[k] + shift[k] < 0) ? 0
+                     : (cj->loc[k] - ci->loc[k] + shift[k] > 0) ? 2
+                                                                : 1);
 
   /* Switch the cells around? */
   const int flipped = runner_flip[sid];

--- a/tests/test125cells.c
+++ b/tests/test125cells.c
@@ -970,7 +970,7 @@ int main(int argc, char *argv[]) {
 
   /* Output timing */
   message("Brute force calculation took : %.3f %s.",
-	  clocks_from_ticks(toc - tic), clocks_getunit());
+          clocks_from_ticks(toc - tic), clocks_getunit());
 
   sprintf(outputFileName, "brute_force_125_%.150s.dat",
           outputFileNameExtension);

--- a/tests/test125cells.c
+++ b/tests/test125cells.c
@@ -969,7 +969,8 @@ int main(int argc, char *argv[]) {
   const ticks toc = getticks();
 
   /* Output timing */
-  message("Brute force calculation took: %15lli ticks.", toc - tic);
+  message("Brute force calculation took : %.3f %s.",
+	  clocks_from_ticks(toc - tic), clocks_getunit());
 
   sprintf(outputFileName, "brute_force_125_%.150s.dat",
           outputFileNameExtension);

--- a/tests/test27cells.c
+++ b/tests/test27cells.c
@@ -630,7 +630,8 @@ int main(int argc, char *argv[]) {
   dump_particle_fields(outputFileName, main_cell, cells);
 
   /* Output timing */
-  message("Brute force calculation took : %15lli ticks.", toc - tic);
+  message("Brute force calculation took : %.3f %s.",
+	  clocks_from_ticks(toc - tic), clocks_getunit());
 
   /* Clean things to make the sanitizer happy ... */
   for (int i = 0; i < 27; ++i) clean_up(cells[i]);

--- a/tests/test27cells.c
+++ b/tests/test27cells.c
@@ -631,7 +631,7 @@ int main(int argc, char *argv[]) {
 
   /* Output timing */
   message("Brute force calculation took : %.3f %s.",
-	  clocks_from_ticks(toc - tic), clocks_getunit());
+          clocks_from_ticks(toc - tic), clocks_getunit());
 
   /* Clean things to make the sanitizer happy ... */
   for (int i = 0; i < 27; ++i) clean_up(cells[i]);

--- a/tests/test27cellsStars.c
+++ b/tests/test27cellsStars.c
@@ -545,7 +545,7 @@ int main(int argc, char *argv[]) {
 
   /* Output timing */
   message("Brute force calculation took : %.3f %s.",
-	  clocks_from_ticks(toc - tic), clocks_getunit());
+          clocks_from_ticks(toc - tic), clocks_getunit());
 
   /* Clean things to make the sanitizer happy ... */
   for (int i = 0; i < 27; ++i) clean_up(cells[i]);

--- a/tests/test27cellsStars.c
+++ b/tests/test27cellsStars.c
@@ -544,7 +544,8 @@ int main(int argc, char *argv[]) {
   dump_particle_fields(outputFileName, main_cell, cells);
 
   /* Output timing */
-  message("Brute force calculation took : %15lli ticks.", toc - tic);
+  message("Brute force calculation took : %.3f %s.",
+	  clocks_from_ticks(toc - tic), clocks_getunit());
 
   /* Clean things to make the sanitizer happy ... */
   for (int i = 0; i < 27; ++i) clean_up(cells[i]);


### PR DESCRIPTION
This PR fixes the test suite when run on the Isambard ARM64 system. There are two types of change: firstly change any remaining clock ticks into human readable format, and secondly running the formatter. With these changes the test suite passes with both the GNU and ARM/Allinea compilers.

When running the test suite load the same modules used to build SWIFT and also the cray-python module. Pip install h5py (with the --user flag) to get testReading.sh to pass. To get testFormat.sh passing set the CLANG_FORMAT_CMD environment variable using 

`export CLANG_FORMAT_CMD=/opt/cray/pe/cce/11.0.4/cce-clang/aarch64/bin/clang-format`